### PR TITLE
Updates interactive assignments, fix quiz time display

### DIFF
--- a/backend/factories/assignment.ts
+++ b/backend/factories/assignment.ts
@@ -118,6 +118,10 @@ export const quizAssignmentCreateInputFactory = () => {
 };
 
 export const interactiveAssignmentCreateInputFactory = () => {
+    return {
+        ...readingAssignmentCreateInputFactory(),
+    };
+
     const language = faker.helpers.arrayElement([
         "javascript",
         "python",

--- a/backend/prisma/migrations/20250218174457_update_tmp_interactive_assignment/migration.sql
+++ b/backend/prisma/migrations/20250218174457_update_tmp_interactive_assignment/migration.sql
@@ -1,0 +1,20 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `codeSnippet` on the `InteractiveAssignment` table. All the data in the column will be lost.
+  - You are about to drop the column `constraints` on the `InteractiveAssignment` table. All the data in the column will be lost.
+  - You are about to drop the column `instructions` on the `InteractiveAssignment` table. All the data in the column will be lost.
+  - You are about to drop the column `language` on the `InteractiveAssignment` table. All the data in the column will be lost.
+  - You are about to drop the column `maxAttempts` on the `InteractiveAssignment` table. All the data in the column will be lost.
+  - You are about to drop the column `testCases` on the `InteractiveAssignment` table. All the data in the column will be lost.
+  - Added the required column `content` to the `InteractiveAssignment` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "InteractiveAssignment" DROP COLUMN "codeSnippet",
+DROP COLUMN "constraints",
+DROP COLUMN "instructions",
+DROP COLUMN "language",
+DROP COLUMN "maxAttempts",
+DROP COLUMN "testCases",
+ADD COLUMN     "content" TEXT NOT NULL;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -125,13 +125,7 @@ model InteractiveAssignment {
   id           Int        @id @default(autoincrement())
   assignmentId Int        @unique
   assignment   Assignment @relation(fields: [assignmentId], references: [id])
-
-  codeSnippet  String
-  language     String // Programming language
-  testCases    Json // List of test cases to validate input/output
-  maxAttempts  Int?
-  constraints  Json? // Optional: Rules, such as memory limits or input length
-  instructions String?
+  content      String
 }
 
 model VideoAssignment {

--- a/backend/tests/utils.ts
+++ b/backend/tests/utils.ts
@@ -158,7 +158,7 @@ export const createPersistentCourse = async (
                     await ctx.prisma.interactiveAssignment.create({
                         data: {
                             assignmentId: assignment.id,
-                            ...interactiveAssignmentCreateInputFactory(),
+                            ...readingAssignmentCreateInputFactory(),
                         },
                     });
                 }

--- a/frontend/src/app/courses/[slug]/Assignment.tsx
+++ b/frontend/src/app/courses/[slug]/Assignment.tsx
@@ -255,7 +255,17 @@ export default function AssignmentComponent({
                             <ReadingAssignmentModal assignment={assignment} />
                         )}
 
-                        {/* quiz ?? */}
+                        {assignment.type === AssignmentType.VIDEO && (
+                            <VideoAssigmentModal
+                                complete={completeAssignment}
+                                assignment={assignment}
+                            />
+                        )}
+
+                        {assignment.type === AssignmentType.INTERACTIVE && (
+                            <ReadingAssignmentModal assignment={assignment} />
+                        )}
+
                         {assignment.type === AssignmentType.QUIZ && (
                             <QuizAssigmentModal
                                 complete={completeAssignment}
@@ -263,19 +273,11 @@ export default function AssignmentComponent({
                             />
                         )}
 
-                        {/* timed */}
                         {assignment.type ===
                             AssignmentType.TIMED_ASSESSMENT && (
                             <QuizAssigmentModal
                                 complete={completeAssignment}
                                 timed={false}
-                                assignment={assignment}
-                            />
-                        )}
-
-                        {assignment.type === AssignmentType.VIDEO && (
-                            <VideoAssigmentModal
-                                complete={completeAssignment}
                                 assignment={assignment}
                             />
                         )}

--- a/frontend/src/app/courses/[slug]/QuizAssigmentModal.tsx
+++ b/frontend/src/app/courses/[slug]/QuizAssigmentModal.tsx
@@ -3,7 +3,6 @@ import { type Assignment } from "@/types";
 import { Progress, Steps } from "antd";
 import React, { useState } from "react";
 import { EllipsisOutlined, EnterOutlined } from "@ant-design/icons";
-import { useRouter } from "next/navigation";
 import { Prisma } from "@prisma/client";
 
 const QuizAssigmentModal = ({
@@ -15,7 +14,6 @@ const QuizAssigmentModal = ({
     timed?: boolean;
     complete: () => Promise<void>;
 }) => {
-    const router = useRouter();
 
     const [started, setStarted] = useState(false);
     const [current, setCurrent] = useState<number>(0);

--- a/frontend/src/app/courses/[slug]/QuizAssigmentModal.tsx
+++ b/frontend/src/app/courses/[slug]/QuizAssigmentModal.tsx
@@ -14,7 +14,6 @@ const QuizAssigmentModal = ({
     timed?: boolean;
     complete: () => Promise<void>;
 }) => {
-
     const [started, setStarted] = useState(false);
     const [current, setCurrent] = useState<number>(0);
     const [submited, setSubmited] = useState(false);
@@ -214,11 +213,10 @@ const QuizAssigmentModal = ({
                 <h1 className="capitalize text-xl">{assignment.title}</h1>
                 <p className="lowercase ">Type: {assignment.type}</p>
                 <p>
-                    {assignment.QuizAssignment?.timeLimit && (
-                        moment.duration(
-                            assignment.QuizAssignment?.timeLimit,
-                        ).humanize() as string
-                    )}
+                    {assignment.QuizAssignment?.timeLimit &&
+                        (moment
+                            .duration(assignment.QuizAssignment?.timeLimit)
+                            .humanize() as string)}
                 </p>
             </div>
             <div className="w-full flex justify-end py-4">

--- a/frontend/src/app/courses/[slug]/QuizAssigmentModal.tsx
+++ b/frontend/src/app/courses/[slug]/QuizAssigmentModal.tsx
@@ -1,3 +1,4 @@
+import moment from "moment";
 import { type Assignment } from "@/types";
 import { Progress, Steps } from "antd";
 import React, { useState } from "react";
@@ -16,7 +17,6 @@ const QuizAssigmentModal = ({
 }) => {
     const router = useRouter();
 
-    // for later fix ...
     const [started, setStarted] = useState(false);
     const [current, setCurrent] = useState<number>(0);
     const [submited, setSubmited] = useState(false);
@@ -28,11 +28,11 @@ const QuizAssigmentModal = ({
     const questions: Prisma.JsonArray = assignment.QuizAssignment
         ?.questions! as Prisma.JsonArray;
 
-    // const items = questions.map((question,i) => ({ key: question.id, title: "" }))
     const items = Object.keys(questions!).map((q, i) => ({
         key: i,
         title: "",
     }));
+
     function submitAnswer() {
         if (!value && value !== 0) {
             setError(true);
@@ -216,11 +216,11 @@ const QuizAssigmentModal = ({
                 <h1 className="capitalize text-xl">{assignment.title}</h1>
                 <p className="lowercase ">Type: {assignment.type}</p>
                 <p>
-                    {assignment.QuizAssignment?.timeLimit &&
-                        (
-                            assignment.QuizAssignment?.timeLimit /
-                            (3600 * 60)
-                        ).toFixed(1) + "mins"}
+                    {assignment.QuizAssignment?.timeLimit && (
+                        moment.duration(
+                            assignment.QuizAssignment?.timeLimit,
+                        ).humanize() as string
+                    )}
                 </p>
             </div>
             <div className="w-full flex justify-end py-4">


### PR DESCRIPTION
This pull request includes changes to the backend and frontend code to refactor the `InteractiveAssignment` model and update the assignment handling logic. The most important changes include modifying the database schema, updating factory functions, and adjusting the frontend components to reflect the new assignment types.

### Backend Changes:

* [`backend/prisma/migrations/20250218174457_update_tmp_interactive_assignment/migration.sql`](diffhunk://#diff-2ee4b096c791a473db082a0bad73996c9815b88cd699739f9938dead8a4851a1R1-R20): Dropped several columns (`codeSnippet`, `constraints`, `instructions`, `language`, `maxAttempts`, `testCases`) from the `InteractiveAssignment` table and added a new `content` column.
* [`backend/prisma/schema.prisma`](diffhunk://#diff-93ead908b5ffa6f6e995757b3739fb02b4e9f8d0ea1da0ec34a9c03c1a33f9bfL128-R128): Updated the `InteractiveAssignment` model to replace the dropped columns with a single `content` column.
* [`backend/factories/assignment.ts`](diffhunk://#diff-60c028f1becbfca795a9f1bec8f31cac0c12e062e97bc382ba83896358055579R121-R124): Added a new `interactiveAssignmentCreateInputFactory` function that utilizes the `readingAssignmentCreateInputFactory` function.
* [`backend/tests/utils.ts`](diffhunk://#diff-9d28a0e6f667f10427e3669e91b0f19f6ea5b1563d4e8d9421b8a62047d90a36L161-R161): Updated the `createPersistentCourse` function to use `readingAssignmentCreateInputFactory` instead of `interactiveAssignmentCreateInputFactory`.

### Frontend Changes:

* `frontend/src/app/courses/[slug]/Assignment.tsx`: Modified the assignment modal rendering logic to handle different assignment types correctly, including `VIDEO`, `INTERACTIVE`, `QUIZ`, and `TIMED_ASSESSMENT`. ([frontend/src/app/courses/[slug]/Assignment.tsxL258-R280](diffhunk://#diff-c06516d54a6ca1987c07db8256a5cd231715f88f27f6dfa7d781540a6b5619c9L258-R280))
* `frontend/src/app/courses/[slug]/QuizAssigmentModal.tsx`: Removed unused imports and code, such as `useRouter`, and replaced the time limit display logic with `moment.duration().humanize()`. ([frontend/src/app/courses/[slug]/QuizAssigmentModal.tsxR1-L5](diffhunk://#diff-5058116f153a53b2e87131dc417c80a144fc790bbdb9cd97b372af32d9ce6165R1-L5), [frontend/src/app/courses/[slug]/QuizAssigmentModal.tsxL17-L19](diffhunk://#diff-5058116f153a53b2e87131dc417c80a144fc790bbdb9cd97b372af32d9ce6165L17-L19), [frontend/src/app/courses/[slug]/QuizAssigmentModal.tsxL31-R33](diffhunk://#diff-5058116f153a53b2e87131dc417c80a144fc790bbdb9cd97b372af32d9ce6165L31-R33), [frontend/src/app/courses/[slug]/QuizAssigmentModal.tsxL219-R221](diffhunk://#diff-5058116f153a53b2e87131dc417c80a144fc790bbdb9cd97b372af32d9ce6165L219-R221))