### PR TITLE
Fixes for video page overflow issues.

### DIFF
--- a/frontend/src/app/courses/[slug]/Assignment.tsx
+++ b/frontend/src/app/courses/[slug]/Assignment.tsx
@@ -272,11 +272,11 @@ export default function AssignmentComponent({
                 footer={footer}
                 getContainer={false}
             >
-                <div className="container mx-auto lg:max-w-6xl  p-6 bg-white">
+                <div className="container flex flex-col h-full overflow-y-auto mx-auto lg:max-w-6xl p-6 bg-white">
                     <header className="flex items-center justify-between mb-6">
                         <Breadcrumb separator=">" items={breadcrumb} />
                     </header>
-                    <div className="overflow-y h-full">
+                    <div>
                         {assignment.type === AssignmentType.READING && (
                             <ReadingAssignmentModal assignment={assignment} />
                         )}

--- a/frontend/src/app/courses/[slug]/ReadingAssignment.tsx
+++ b/frontend/src/app/courses/[slug]/ReadingAssignment.tsx
@@ -9,7 +9,7 @@ export const ReadingAssignmentModal = ({
     return (
         <>
             <article
-                className="prose-lg overflow-y-auto max-h-[80vh]"
+                className="prose-lg"
                 dangerouslySetInnerHTML={{
                     __html: assignment.ReadingAssignment?.content || "",
                 }}

--- a/frontend/src/app/courses/[slug]/VideoAssigmentModal.tsx
+++ b/frontend/src/app/courses/[slug]/VideoAssigmentModal.tsx
@@ -41,7 +41,10 @@ const VideoAssigmentModal = ({
     return (
         <>
             <section className="w-full flex gap-2">
-                <div dangerouslySetInnerHTML={{ __html: videoUrl }}></div>
+                <div
+                    className="w-full"
+                    dangerouslySetInnerHTML={{ __html: videoUrl }}
+                ></div>
                 {/* tooltips */}
                 <div className="p-2 py-4 flex flex-col gap-2 border rounded-md max-h-fit border-slate-300 dark:border-slate-700">
                     {videoTools.map((tool) => (


### PR DESCRIPTION
Loom video embeds were collapsing instead of filling the available space, and video page transcripts were overflowing the page height. This should fix these issues.